### PR TITLE
ignore errors for suspended or protected users

### DIFF
--- a/tests/test_twacapic.py
+++ b/tests/test_twacapic.py
@@ -1,3 +1,5 @@
+# pylint: disable=W1514,W0621,C0116
+
 import json
 import os
 import shutil
@@ -537,16 +539,17 @@ def test_expansions_in_tweets(user_group_with_tweets):
                 assert 'tweets' in tweets['includes']
 
 
-def test_non_reachable_users(user_group_with_deleted_protected_accounts):
+def test_non_reachable_users(user_group_with_deleted_protected_accounts: UserGroup):
 
     user_group_with_deleted_protected_accounts.collect()
     print(user_group_with_deleted_protected_accounts.user_ids)
 
-    assert os.listdir(user_group_with_deleted_protected_accounts.path) == ['group_config.yaml']
+    for item in os.listdir(user_group_with_deleted_protected_accounts.path):
+        assert item in ['group_config.yaml','2530965517','557558765']
 
     user_group_with_deleted_protected_accounts.collect()  # check second time for errors because of missing metadata etc.
 
     assert (Path.cwd()/'results'/'test_non_reachable_users').is_dir()
     assert (Path.cwd()/'results'/'deleted_test_non_reachable_users').is_dir()
-    assert (Path.cwd()/'results'/'protected_test_non_reachable_users').is_dir()
-    assert (Path.cwd()/'results'/'suspended_test_non_reachable_users').is_dir()
+    assert not (Path.cwd()/'results'/'protected_test_non_reachable_users').exists()
+    assert not (Path.cwd()/'results'/'suspended_test_non_reachable_users').exists()

--- a/tests/test_twacapic.py
+++ b/tests/test_twacapic.py
@@ -46,7 +46,7 @@ def user_group_with_deleted_protected_accounts():
     yield user_group
 
     shutil.rmtree(Path.cwd()/'results'/'test_non_reachable_users')
-    shutil.rmtree(Path.cwd()/'results'/'deleted_test_non_reachable_users')
+    # shutil.rmtree(Path.cwd()/'results'/'deleted_test_non_reachable_users')
     # shutil.rmtree(Path.cwd()/'results'/'protected_test_non_reachable_users')
     # shutil.rmtree(Path.cwd()/'results'/'suspended_test_non_reachable_users')
 

--- a/tests/test_twacapic.py
+++ b/tests/test_twacapic.py
@@ -550,6 +550,6 @@ def test_non_reachable_users(user_group_with_deleted_protected_accounts: UserGro
     user_group_with_deleted_protected_accounts.collect()  # check second time for errors because of missing metadata etc.
 
     assert (Path.cwd()/'results'/'test_non_reachable_users').is_dir()
-    assert (Path.cwd()/'results'/'deleted_test_non_reachable_users').is_dir()
+    assert not (Path.cwd()/'results'/'deleted_test_non_reachable_users').exists()
     assert not (Path.cwd()/'results'/'protected_test_non_reachable_users').exists()
     assert not (Path.cwd()/'results'/'suspended_test_non_reachable_users').exists()

--- a/tests/test_twacapic.py
+++ b/tests/test_twacapic.py
@@ -545,7 +545,7 @@ def test_non_reachable_users(user_group_with_deleted_protected_accounts: UserGro
     print(user_group_with_deleted_protected_accounts.user_ids)
 
     for item in os.listdir(user_group_with_deleted_protected_accounts.path):
-        assert item in ['group_config.yaml','2530965517','557558765']
+        assert item in ['group_config.yaml', '2530965517', '557558765', '11']
 
     user_group_with_deleted_protected_accounts.collect()  # check second time for errors because of missing metadata etc.
 

--- a/tests/test_twacapic.py
+++ b/tests/test_twacapic.py
@@ -45,8 +45,8 @@ def user_group_with_deleted_protected_accounts():
 
     yield user_group
 
-    # shutil.rmtree(Path.cwd()/'results'/'test_non_reachable_users')
-    # shutil.rmtree(Path.cwd()/'results'/'deleted_test_non_reachable_users')
+    shutil.rmtree(Path.cwd()/'results'/'test_non_reachable_users')
+    shutil.rmtree(Path.cwd()/'results'/'deleted_test_non_reachable_users')
     # shutil.rmtree(Path.cwd()/'results'/'protected_test_non_reachable_users')
     # shutil.rmtree(Path.cwd()/'results'/'suspended_test_non_reachable_users')
 

--- a/tests/test_twacapic.py
+++ b/tests/test_twacapic.py
@@ -539,7 +539,7 @@ def test_expansions_in_tweets(user_group_with_tweets):
                 assert 'tweets' in tweets['includes']
 
 
-def test_non_reachable_users(user_group_with_deleted_protected_accounts: UserGroup):
+def test_non_reachable_users(user_group_with_deleted_protected_accounts):
 
     user_group_with_deleted_protected_accounts.collect()
     print(user_group_with_deleted_protected_accounts.user_ids)

--- a/twacapic/collect.py
+++ b/twacapic/collect.py
@@ -90,18 +90,10 @@ class UserGroup:
                                     dirs_exist_ok=True
                                     )
                     shutil.rmtree(Path.cwd()/'results'/self.name/user_id)
-                elif tweets['errors'][0]['title'] == 'Forbidden':
-                    shutil.copytree(Path.cwd()/'results'/self.name/user_id,
-                                    Path.cwd()/'results'/f'suspended_{self.name}'/user_id,
-                                    dirs_exist_ok=True
-                                    )
-                    shutil.rmtree(Path.cwd()/'results'/self.name/user_id)
-                elif tweets['errors'][0]['title'] == 'Authorization Error':
-                    shutil.copytree(Path.cwd()/'results'/self.name/user_id,
-                                    Path.cwd()/'results'/f'protected_{self.name}'/user_id,
-                                    dirs_exist_ok=True
-                                    )
-                    shutil.rmtree(Path.cwd()/'results'/self.name/user_id)
+                elif tweets['errors'][0]['title'] == 'Forbidden' or\
+                    tweets['errors'][0]['title'] == 'Authorization Error':
+                    #  ignore suspended and protected account errors
+                    return None
                 else:
                     raise TwitterRequestError(200, f"{tweets['errors']}")
 

--- a/twacapic/collect.py
+++ b/twacapic/collect.py
@@ -3,7 +3,6 @@ import os
 import shutil
 import time
 from glob import glob
-from pathlib import Path
 
 import twacapic.templates
 import yaml
@@ -82,22 +81,16 @@ class UserGroup:
 
             if 'errors' in tweets and 'data' not in tweets:
 
-                logger.error(tweets["errors"])
+                logger.warning(tweets["errors"])
 
                 if tweets['errors'][0]['title'] == 'Not Found Error':
-                    shutil.copytree(Path.cwd()/'results'/self.name/user_id,
-                                    Path.cwd()/'results'/f'deleted_{self.name}'/user_id,
-                                    dirs_exist_ok=True
-                                    )
-                    shutil.rmtree(Path.cwd()/'results'/self.name/user_id)
-                elif tweets['errors'][0]['title'] == 'Forbidden' or\
-                    tweets['errors'][0]['title'] == 'Authorization Error':
-                    #  ignore suspended and protected account errors
-                    return None
+                    logger.warning(f'{user_id} not found.')
+                elif tweets['errors'][0]['title'] == 'Forbidden':
+                    logger.warning(f'{user_id} forbidden.')
+                elif tweets['errors'][0]['title'] == 'Authorization Error':
+                    logger.warning(f'{user_id} Authorization Error.')
                 else:
                     raise TwitterRequestError(200, f"{tweets['errors']}")
-
-                self.user_ids.remove(user_id)
 
                 return None
 


### PR DESCRIPTION
Changes handling for errors for suspended and protected users:

- user-folders will not be moved to another directory
- an, thus, will still included in each call.

Closes #20.