### PR TITLE
add get_all_the_tweets parameter to UserGroup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,4 @@ results
 users.csv
 *gmail_creds.json*
 gmail_creds.yaml
+1user.csv

--- a/tests/test_twacapic.py
+++ b/tests/test_twacapic.py
@@ -38,6 +38,16 @@ def user_group():
 
 
 @pytest.fixture
+def user_group_to_get_all_the_tweets():
+
+    user_group = UserGroup('tests/mock_files/users.csv', name='test_users_get_all_the_tweets', get_all_the_tweets=True)
+
+    yield user_group
+
+    shutil.rmtree('results/test_users_get_all_the_tweets')
+
+
+@pytest.fixture
 def user_group_with_deleted_protected_accounts():
 
     user_group = UserGroup('tests/mock_files/protected_nonexistent_users.csv',
@@ -553,3 +563,15 @@ def test_non_reachable_users(user_group_with_deleted_protected_accounts):
     assert not (Path.cwd()/'results'/'deleted_test_non_reachable_users').exists()
     assert not (Path.cwd()/'results'/'protected_test_non_reachable_users').exists()
     assert not (Path.cwd()/'results'/'suspended_test_non_reachable_users').exists()
+
+
+def test_user_group_setup_for_getting_all_the_tweets(user_group_to_get_all_the_tweets):
+
+    for user_id in user_group_to_get_all_the_tweets.user_ids:
+        meta_file_path = f'{user_group_to_get_all_the_tweets.path}/{user_id}/meta.yaml'
+
+        with open(meta_file_path, 'r') as f:
+            metadata = yaml.safe_load(f)
+
+        assert metadata['newest_id'] == metadata['oldest_id']
+        assert metadata['newest_id'] == '0'

--- a/twacapic/collect.py
+++ b/twacapic/collect.py
@@ -15,9 +15,9 @@ logger.remove()
 
 class UserGroup:
 
-    def __init__(self, path=None, name=None, config=None):
+    def __init__(self, path=None, name=None, config=None, get_all_the_tweets=False):
 
-        self.source_path = path
+        self.source_path = path  # TODO: better naming, path is the path to the list of ids, not to the group folder
         self.path = f'results/{name}'
         self.name = name
 
@@ -27,6 +27,14 @@ class UserGroup:
                 for line in file:
                     user_id = line.strip()
                     os.makedirs(f'results/{name}/{user_id}', exist_ok=True)
+
+                    if get_all_the_tweets is True:
+                        meta_file_path = f'{self.path}/{user_id}/meta.yaml'
+                        user_metadata = {'newest_id': '0', 'oldest_id': '0'}
+
+                        with open(meta_file_path, 'w') as metafile:
+                            yaml.dump(user_metadata, metafile)
+
                     self.user_ids.append(user_id)
         else:
             self.user_ids = [

--- a/twacapic/main.py
+++ b/twacapic/main.py
@@ -51,6 +51,11 @@ def run():
         '-n', '--notify',
         help='If given, notify email address in case of unexpected errors. Needs further setup. See README.'
     )
+    parser.add_argument(
+        '-a', '--get_all_the_tweets',
+        action='store_true',
+        help='Get all available tweets (max. 3200) for a user on the first run.'
+    )
 
     args = parser.parse_args()
 
@@ -73,7 +78,7 @@ def run():
 
         save_credentials('twitter_keys.yaml', consumer_key, consumer_secret)
 
-    def one_run(userlist, groupname, config):
+    def one_run(userlist, groupname, config, get_all_the_tweets=False):
 
         if userlist is None:
             userlist = [None] * len(groupname)
@@ -83,7 +88,7 @@ def run():
         for userlist, groupname in userlists_and_groupnames:
 
             user_group = UserGroup(path=userlist, name=groupname,
-                                   config=config)
+                                   config=config, get_all_the_tweets=get_all_the_tweets)
 
             logger.info(f"Starting collection of {groupname}.")
 
@@ -92,7 +97,7 @@ def run():
             logger.info(f"Finished collection of {groupname}.")
 
     if args.schedule is None:
-        one_run(args.userlist, args.groupname, args.group_config)
+        one_run(args.userlist, args.groupname, args.group_config, args.get_all_the_tweets)
     else:
 
         if args.notify is not None:
@@ -105,7 +110,7 @@ def run():
 
         previous = overwrite('Wake up, samurai, we have work to do …', 0)
 
-        one_run(args.userlist, args.groupname, args.group_config)
+        one_run(args.userlist, args.groupname, args.group_config, args.get_all_the_tweets)
 
         while True:
             try:


### PR DESCRIPTION
Addresses #23 partly.

Instead of a 'true' historic search, this PR introduces a CL argument to retrieve all tweets available via the user endpoint. This is much easier to implement and gives a user usually months to years of tweets (max. 3200 tweets), except for very active accounts.

Implementation:

To minimize changes to the code and tests, I adapted the UserGroup class to precreate a meta-file with '0' for the latest collected id for every user. This tricks the rest of the code into retrieving all tweets available.

Caveats:

The '-a' CL toggle should not be used when a group already has data. However, the worst case should be a duplication of already collected data.